### PR TITLE
add config encrypt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "psr-4": {
       "Mine\\Tests\\": "tests",
       "Xmo\\AppStore\\Tests\\": "src/app-store/tests",
+      "Xmo\\MineCore\\Tests\\": "src/mine-core/tests",
       "Mine\\NextCoreX\\Tests\\": "src/next-core-x/tests"
     }
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
           - src/mine/src/Helper/Ip2region.php
           - src/gateway/*
           - src/next-core-x/tests/*
+          - src/mine-core/tests/*
           - src/tests/
           - src/app-store/test/
   ignoreErrors:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,7 @@
   <testsuites>
     <testsuite name="Tests">
       <directory suffix="Test.php">./src/app-store/tests</directory>
+      <directory suffix="Test.php">./src/mine-core/tests</directory>
       <directory suffix="Test.php">./src/next-core-x/tests</directory>
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
@@ -11,6 +12,7 @@
   <source>
     <include>
       <directory suffix=".php">./src/app-store/tests</directory>
+      <directory suffix=".php">./src/mine-core/tests</directory>
       <directory suffix=".php">./src/next-core-x/tests</directory>
       <directory suffix=".php">./tests</directory>
     </include>

--- a/src/mine-core/publish/mineadmin.php
+++ b/src/mine-core/publish/mineadmin.php
@@ -19,4 +19,8 @@ return [
     'excel_drive' => 'auto',
     // 是否启用 远程通用列表查询 功能
     'remote_api_enabled' => true,
+
+    'config_encryption' => false,
+    'config_encryption_key' => 'oqye5o39exzj47LDFMT2oxRJUmy18Fwo0LB006Uo6fk=',
+    'config_encryption_iv' => 'bQEvWfcM6xlt3ZtYgBoK/A==',
 ];

--- a/src/mine-core/src/Aspect/ConfigCryptAspect.php
+++ b/src/mine-core/src/Aspect/ConfigCryptAspect.php
@@ -1,5 +1,15 @@
 <?php
 
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+
 namespace Mine\Aspect;
 
 use Hyperf\Di\Annotation\Aspect;
@@ -17,7 +27,9 @@ class ConfigCryptAspect extends AbstractAspect
     ];
 
     private ?bool $enable = null;
+
     private ?string $key = null;
+
     private ?string $iv = null;
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
@@ -32,7 +44,7 @@ class ConfigCryptAspect extends AbstractAspect
         $config = (array) $result;
         $config = array_shift($config);
 
-        foreach($config as $key => $value) {
+        foreach ($config as $key => $value) {
             if ($key != 'mineadmin') {
                 if (is_array($value)) {
                     $result->set($key, $this->processDecryption($result, $value));
@@ -41,11 +53,9 @@ class ConfigCryptAspect extends AbstractAspect
         }
     }
 
-
-
     private function processDecryption($result, $config): array
     {
-        foreach($config as $key => $value) {
+        foreach ($config as $key => $value) {
             if (is_array($value)) {
                 $config[$key] = $this->processDecryption($result, $value);
             } else {
@@ -56,21 +66,21 @@ class ConfigCryptAspect extends AbstractAspect
                         }
                         if (is_null($this->key)) {
                             $this->key = $result->get('mineadmin.config_encryption_key', '');
-                            if (!empty($this->key)) {
+                            if (! empty($this->key)) {
                                 $this->key = @base64_decode($this->key);
                             }
                         }
 
                         if (is_null($this->key)) {
                             $this->key = $result->get('mineadmin.config_encryption_key', '');
-                            if (!empty($this->key)) {
+                            if (! empty($this->key)) {
                                 $this->key = @base64_decode($this->key);
                             }
                         }
 
                         if (is_null($this->iv)) {
                             $this->iv = $result->get('mineadmin.config_encryption_iv', '');
-                            if (!empty($this->iv)) {
+                            if (! empty($this->iv)) {
                                 $this->iv = @base64_decode($this->iv);
                             }
                         }

--- a/src/mine-core/src/Aspect/ConfigCryptAspect.php
+++ b/src/mine-core/src/Aspect/ConfigCryptAspect.php
@@ -35,7 +35,12 @@ class ConfigCryptAspect extends AbstractAspect
     public function process(ProceedingJoinPoint $proceedingJoinPoint)
     {
         $result = $proceedingJoinPoint->process();
-        $this->processConfig($result);
+        if (is_null($this->enable)) {
+            $this->enable = (bool) $result->get('mineadmin.config_encryption', false);
+        }
+        if ($this->enable) {
+            $this->processConfig($result);
+        }
         return $result;
     }
 
@@ -61,16 +66,6 @@ class ConfigCryptAspect extends AbstractAspect
             } else {
                 if (is_string($value)) {
                     if (preg_match('#ENC\((.*?)\)#is', $value, $matches)) {
-                        if (is_null($this->enable)) {
-                            $this->enable = $result->get('mineadmin.config_encryption_key', false);
-                        }
-                        if (is_null($this->key)) {
-                            $this->key = $result->get('mineadmin.config_encryption_key', '');
-                            if (! empty($this->key)) {
-                                $this->key = @base64_decode($this->key);
-                            }
-                        }
-
                         if (is_null($this->key)) {
                             $this->key = $result->get('mineadmin.config_encryption_key', '');
                             if (! empty($this->key)) {
@@ -89,6 +84,7 @@ class ConfigCryptAspect extends AbstractAspect
                         if (empty($value)) {
                             $value = $matches[1];
                         }
+
                         $config[$key] = $value;
                     }
                 }

--- a/src/mine-core/src/Aspect/ConfigCryptAspect.php
+++ b/src/mine-core/src/Aspect/ConfigCryptAspect.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Mine\Aspect;
 
-use Hyperf\Di\Annotation\Aspect;
 use Hyperf\Di\Aop\AbstractAspect;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 

--- a/src/mine-core/src/Aspect/ConfigCryptAspect.php
+++ b/src/mine-core/src/Aspect/ConfigCryptAspect.php
@@ -19,7 +19,6 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 /**
  * Class ConfigCryptAspect.
  */
-#[Aspect]
 class ConfigCryptAspect extends AbstractAspect
 {
     public array $classes = [

--- a/src/mine-core/src/Aspect/ConfigCryptAspect.php
+++ b/src/mine-core/src/Aspect/ConfigCryptAspect.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Mine\Aspect;
+
+use Hyperf\Di\Annotation\Aspect;
+use Hyperf\Di\Aop\AbstractAspect;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+
+/**
+ * Class ConfigCryptAspect.
+ */
+#[Aspect]
+class ConfigCryptAspect extends AbstractAspect
+{
+    public array $classes = [
+        'Hyperf\Config\ConfigFactory::__invoke',
+    ];
+
+    private ?bool $enable = null;
+    private ?string $key = null;
+    private ?string $iv = null;
+
+    public function process(ProceedingJoinPoint $proceedingJoinPoint)
+    {
+        $result = $proceedingJoinPoint->process();
+        $this->processConfig($result);
+        return $result;
+    }
+
+    private function processConfig($result)
+    {
+        $config = (array) $result;
+        $config = array_shift($config);
+
+        foreach($config as $key => $value) {
+            if ($key != 'mineadmin') {
+                if (is_array($value)) {
+                    $result->set($key, $this->processDecryption($result, $value));
+                }
+            }
+        }
+    }
+
+
+
+    private function processDecryption($result, $config): array
+    {
+        foreach($config as $key => $value) {
+            if (is_array($value)) {
+                $config[$key] = $this->processDecryption($result, $value);
+            } else {
+                if (is_string($value)) {
+                    if (preg_match('#ENC\((.*?)\)#is', $value, $matches)) {
+                        if (is_null($this->enable)) {
+                            $this->enable = $result->get('mineadmin.config_encryption_key', false);
+                        }
+                        if (is_null($this->key)) {
+                            $this->key = $result->get('mineadmin.config_encryption_key', '');
+                            if (!empty($this->key)) {
+                                $this->key = @base64_decode($this->key);
+                            }
+                        }
+
+                        if (is_null($this->key)) {
+                            $this->key = $result->get('mineadmin.config_encryption_key', '');
+                            if (!empty($this->key)) {
+                                $this->key = @base64_decode($this->key);
+                            }
+                        }
+
+                        if (is_null($this->iv)) {
+                            $this->iv = $result->get('mineadmin.config_encryption_iv', '');
+                            if (!empty($this->iv)) {
+                                $this->iv = @base64_decode($this->iv);
+                            }
+                        }
+
+                        $value = @openssl_decrypt($matches[1], 'AES-128-CBC', $this->key, 0, $this->iv);
+                        if (empty($value)) {
+                            $value = $matches[1];
+                        }
+                        $config[$key] = $value;
+                    }
+                }
+            }
+        }
+        return $config;
+    }
+}

--- a/src/mine-core/src/Command/ConfigCryptCommand.php
+++ b/src/mine-core/src/Command/ConfigCryptCommand.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * MineAdmin is committed to providing solutions for quickly building web applications
+ * Please view the LICENSE file that was distributed with this source code,
+ * For the full copyright and license information.
+ * Thank you very much for using MineAdmin.
+ *
+ * @Author X.Mo<root@imoi.cn>
+ * @Link   https://gitee.com/xmo/MineAdmin
+ */
+
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+
+namespace Mine\Command;
+
+use Hyperf\Command\Annotation\Command;
+use Hyperf\Context\ApplicationContext;
+use Mine\Helper\Str;
+use Mine\MineCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Class JwtCommand.
+ */
+#[Command]
+class ConfigCryptCommand extends MineCommand
+{
+    /**
+     * 生成JWT密钥命令.
+     */
+    protected ?string $name = 'mine:config-crypt';
+
+    public function configure()
+    {
+        parent::configure();
+        $this->setHelp('run "php bin/hyperf.php mine:config-crypt" encrypt');
+        $this->setDescription('MineAdmin system config crypt command');
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function handle()
+    {
+        $value = $this->input->getArgument('value');
+        $key = config('mineadmin.config_encryption_key', '');
+        if (empty($key)) {
+            $this->line('Not found mineadmin.config_encryption_key config.', 'error');
+            return self::FAILURE;
+        }
+
+        $key = @base64_decode($key);
+        if (empty($key)) {
+            $this->line('key content error.', 'error');
+            return self::FAILURE;
+        }
+
+        $iv = config('mineadmin.config_encryption_iv', '');
+        if (empty($iv)) {
+            $this->line('Not found mineadmin.config_encryption_iv config.', 'error');
+            return self::FAILURE;
+        }
+
+        $iv = @base64_decode($iv);
+        if (empty($iv)) {
+            $this->line('iv content error.', 'error');
+            return self::FAILURE;
+        }
+
+        $encrypt = @openssl_encrypt($value, 'AES-128-CBC', $key,  0, $iv);
+
+        if (empty($encrypt)) {
+            $this->line('iv or key content error.please regen', 'error');
+            return self::FAILURE;
+        }
+
+        $this->info('config crypt string is: ENC(' . $encrypt .')');
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['value', InputArgument::REQUIRED, 'source value']
+        ];
+    }
+}

--- a/src/mine-core/src/Command/ConfigCryptCommand.php
+++ b/src/mine-core/src/Command/ConfigCryptCommand.php
@@ -24,6 +24,7 @@ namespace Mine\Command;
 use Hyperf\Command\Annotation\Command;
 use Mine\MineCommand;
 use Symfony\Component\Console\Input\InputArgument;
+use function Hyperf\Config\config;
 
 /**
  * Class JwtCommand.

--- a/src/mine-core/src/Command/ConfigCryptCommand.php
+++ b/src/mine-core/src/Command/ConfigCryptCommand.php
@@ -24,6 +24,7 @@ namespace Mine\Command;
 use Hyperf\Command\Annotation\Command;
 use Mine\MineCommand;
 use Symfony\Component\Console\Input\InputArgument;
+
 use function Hyperf\Config\config;
 
 /**

--- a/src/mine-core/src/Command/ConfigCryptCommand.php
+++ b/src/mine-core/src/Command/ConfigCryptCommand.php
@@ -22,11 +22,8 @@ declare(strict_types=1);
 namespace Mine\Command;
 
 use Hyperf\Command\Annotation\Command;
-use Hyperf\Context\ApplicationContext;
-use Mine\Helper\Str;
 use Mine\MineCommand;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class JwtCommand.
@@ -76,20 +73,20 @@ class ConfigCryptCommand extends MineCommand
             return self::FAILURE;
         }
 
-        $encrypt = @openssl_encrypt($value, 'AES-128-CBC', $key,  0, $iv);
+        $encrypt = @openssl_encrypt($value, 'AES-128-CBC', $key, 0, $iv);
 
         if (empty($encrypt)) {
             $this->line('iv or key content error.please regen', 'error');
             return self::FAILURE;
         }
 
-        $this->info('config crypt string is: ENC(' . $encrypt .')');
+        $this->info('config crypt string is: ENC(' . $encrypt . ')');
     }
 
     protected function getArguments()
     {
         return [
-            ['value', InputArgument::REQUIRED, 'source value']
+            ['value', InputArgument::REQUIRED, 'source value'],
         ];
     }
 }

--- a/src/mine-core/src/Command/ConfigCryptGenCommand.php
+++ b/src/mine-core/src/Command/ConfigCryptGenCommand.php
@@ -22,9 +22,7 @@ declare(strict_types=1);
 namespace Mine\Command;
 
 use Hyperf\Command\Annotation\Command;
-use Mine\Helper\Str;
 use Mine\MineCommand;
-use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Class JwtCommand.
@@ -33,7 +31,7 @@ use Symfony\Component\Console\Input\InputOption;
 class ConfigCryptGenCommand extends MineCommand
 {
     /**
-     * 生成key和向量
+     * 生成key和向量.
      */
     protected ?string $name = 'mine:config-crypt-gen';
 
@@ -49,12 +47,10 @@ class ConfigCryptGenCommand extends MineCommand
      */
     public function handle()
     {
-
         $key = base64_encode(random_bytes(32));
         $iv = base64_encode(random_bytes(openssl_cipher_iv_length('AES-128-CBC')));
 
         $this->info('config encrypt key generator successfully:' . $key);
         $this->info('config encrypt iv generator successfully:' . $iv);
     }
-
 }

--- a/src/mine-core/src/Command/ConfigCryptGenCommand.php
+++ b/src/mine-core/src/Command/ConfigCryptGenCommand.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * MineAdmin is committed to providing solutions for quickly building web applications
+ * Please view the LICENSE file that was distributed with this source code,
+ * For the full copyright and license information.
+ * Thank you very much for using MineAdmin.
+ *
+ * @Author X.Mo<root@imoi.cn>
+ * @Link   https://gitee.com/xmo/MineAdmin
+ */
+
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+
+namespace Mine\Command;
+
+use Hyperf\Command\Annotation\Command;
+use Mine\Helper\Str;
+use Mine\MineCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Class JwtCommand.
+ */
+#[Command]
+class ConfigCryptGenCommand extends MineCommand
+{
+    /**
+     * 生成key和向量
+     */
+    protected ?string $name = 'mine:config-crypt-gen';
+
+    public function configure()
+    {
+        parent::configure();
+        $this->setHelp('run "php bin/hyperf.php mine:config-crypt-gen" create the key and iv for config encrypt');
+        $this->setDescription('MineAdmin system gen config crypt key and iv command');
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function handle()
+    {
+
+        $key = base64_encode(random_bytes(32));
+        $iv = base64_encode(random_bytes(openssl_cipher_iv_length('AES-128-CBC')));
+
+        $this->info('config encrypt key generator successfully:' . $key);
+        $this->info('config encrypt iv generator successfully:' . $iv);
+    }
+
+}

--- a/src/mine-core/tests/Feature/ConfigCryptAspectTest.php
+++ b/src/mine-core/tests/Feature/ConfigCryptAspectTest.php
@@ -18,11 +18,11 @@ beforeEach(function () {
     $this->configEnable = new Config([
         'mineadmin' => [
             'config_encryption' => true,
-            'config_encryption_key' => '1234567890',
-            'config_encryption_iv' => '1234567890',
+            'config_encryption_key' => '8W2w7QNSaBsSqRk2LHWoAbXpMOE3piGYo6VAImvdrZk=',
+            'config_encryption_iv' => 'RqoZmqew71IUd9jW3mZ6QQ==',
         ],
         'test' => [
-            'key1' => 'ENC(6SX9TNnNO7KH+WFTOmVOFZ2jGsbR4K/0M0BwXvxtu34=)',
+            'key1' => 'ENC(YMKaQ9qIhnHANf3Cnpi05Q=)',
         ],
     ]);
     $this->configDisable = new Config([
@@ -41,7 +41,7 @@ test(ConfigCryptAspect::class . ' testing', function () {
     // enable
     $configCryptAspect = new ConfigCryptAspect();
     $config = $configCryptAspect->process($this->proceedingJoinPoint);
-    //    var_dump($config , $this->configEnable);
+        var_dump($config , $this->configEnable);
     expect($config !== $this->configEnable)->toBeFalse();
 
     // disable

--- a/src/mine-core/tests/Feature/ConfigCryptAspectTest.php
+++ b/src/mine-core/tests/Feature/ConfigCryptAspectTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+use Hyperf\Config\Config;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Mine\Aspect\ConfigCryptAspect;
+
+beforeEach(function () {
+    $proceedingJoinPoint = Mockery::mock(ProceedingJoinPoint::class);
+    $this->configEnable = new Config([
+        'mineadmin' => [
+            'config_encryption' => true,
+            'config_encryption_key' => '1234567890',
+            'config_encryption_iv' => '1234567890',
+        ],
+        'test' => [
+            'key1' => 'ENC(6SX9TNnNO7KH+WFTOmVOFZ2jGsbR4K/0M0BwXvxtu34=)',
+        ],
+    ]);
+    $this->configDisable = new Config([
+        'mineadmin' => [
+            'config_encryption' => false,
+        ],
+        'test' => [
+            'key1' => 'ENC(6SX9TNnNO7KH+WFTOmVOFZ2jGsbR4K/0M0BwXvxtu34=)',
+        ],
+    ]);
+    $proceedingJoinPoint->allows('process')->andReturn($this->configEnable, $this->configDisable);
+    $this->proceedingJoinPoint = $proceedingJoinPoint;
+});
+
+test(ConfigCryptAspect::class . ' testing', function () {
+    // enable
+    $configCryptAspect = new ConfigCryptAspect();
+    $config = $configCryptAspect->process($this->proceedingJoinPoint);
+    //    var_dump($config , $this->configEnable);
+    expect($config !== $this->configEnable)->toBeFalse();
+
+    // disable
+
+    $configCryptAspect = new ConfigCryptAspect();
+    $config = $configCryptAspect->process($this->proceedingJoinPoint);
+    expect($config !== $this->configEnable)->toBeTrue();
+});

--- a/src/mine-core/tests/Feature/ConfigCryptAspectTest.php
+++ b/src/mine-core/tests/Feature/ConfigCryptAspectTest.php
@@ -14,15 +14,14 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Mine\Aspect\ConfigCryptAspect;
 
 beforeEach(function () {
-    $proceedingJoinPoint = Mockery::mock(ProceedingJoinPoint::class);
     $this->configEnable = new Config([
         'mineadmin' => [
             'config_encryption' => true,
-            'config_encryption_key' => '8W2w7QNSaBsSqRk2LHWoAbXpMOE3piGYo6VAImvdrZk=',
-            'config_encryption_iv' => 'RqoZmqew71IUd9jW3mZ6QQ==',
+            'config_encryption_key' => 'N1pQLQd8qkTDvb//iOwZ5uGvpBusW6PsNwbKUXroXKE=',
+            'config_encryption_iv' => 'ZmGep5xz4oFCfDrzzHJ26Q==',
         ],
         'test' => [
-            'key1' => 'ENC(YMKaQ9qIhnHANf3Cnpi05Q=)',
+            'key1' => 'ENC(qJhrnXpKmxZJC2MxNoTAbg==)',
         ],
     ]);
     $this->configDisable = new Config([
@@ -33,20 +32,24 @@ beforeEach(function () {
             'key1' => 'ENC(6SX9TNnNO7KH+WFTOmVOFZ2jGsbR4K/0M0BwXvxtu34=)',
         ],
     ]);
-    $proceedingJoinPoint->allows('process')->andReturn($this->configEnable, $this->configDisable);
-    $this->proceedingJoinPoint = $proceedingJoinPoint;
 });
 
 test(ConfigCryptAspect::class . ' testing', function () {
     // enable
+    $proceedingJoinPoint = Mockery::mock(ProceedingJoinPoint::class);
+    $proceedingJoinPoint->allows('process')->andreturn($this->configEnable);
     $configCryptAspect = new ConfigCryptAspect();
-    $config = $configCryptAspect->process($this->proceedingJoinPoint);
-        var_dump($config , $this->configEnable);
-    expect($config !== $this->configEnable)->toBeFalse();
+    $config = $configCryptAspect->process($proceedingJoinPoint);
+    expect($config !== $this->configEnable)
+        ->toBeFalse()
+        ->and($config->get('test.key1'))
+        ->toEqual('1234');
 
     // disable
 
+    $proceedingJoinPoint = Mockery::mock(ProceedingJoinPoint::class);
+    $proceedingJoinPoint->allows('process')->andreturn($this->configDisable);
     $configCryptAspect = new ConfigCryptAspect();
-    $config = $configCryptAspect->process($this->proceedingJoinPoint);
-    expect($config !== $this->configEnable)->toBeTrue();
+    $config = $configCryptAspect->process($proceedingJoinPoint);
+    expect($config)->toEqual($this->configDisable);
 });


### PR DESCRIPTION
开启配置文件加密
config/autoload/mineadmin.php
```
   // 是否开启加密
    'config_encryption' => false,
    'config_encryption_key' => 'oqye5o39exzj47LDFMT2oxRJUmy18Fwo0LB006Uo6fk=',
    'config_encryption_iv' => 'bQEvWfcM6xlt3ZtYgBoK/A==',
```

生成key和向量
```
$ swoole-cli bin/hyperf.php mine:config-crypt-gen
config encrypt key generator successfully:Y9ozU3eAzlCGVQgV6rr1tEZ/pHORcXO+Y3yIBOsrnGw=
config encrypt iv generator successfully:elvcz9OWCUQwhg/glhBSbA==
```

替换配置里的key 和iv

加密内容

```
$ swoole-cli bin/hyperf.php mine:config-crypt 127.0.0.1
config crypt string is: ENC(1d960HOueiIZycVRhSKcFA==)
```

替换.env
DB_HOST = "ENC(7qxSDf406CtEeNVo6D5q/w==)"


