### PR TITLE
Fix the inability to generate a mod in the case of a plural form of table name prefix_table_name(s)

### DIFF
--- a/CHANGELOG-2.0.md
+++ b/CHANGELOG-2.0.md
@@ -10,3 +10,4 @@
 - [#58](https://github.com/mineadmin/components/pull/58) New base Secure Authentication Component
 - [#59](https://github.com/mineadmin/components/pull/59) Add components for secure access control
 - - [#61](https://github.com/mineadmin/components/pull/61) Provide associative access to exported path attributes
+- [#64](https://github.com/mineadmin/components/pull/64) Fix the inability to generate a mod in the case of a plural form of table name prefix_table_name(s)

--- a/CHANGELOG-2.0.zh_CN.md
+++ b/CHANGELOG-2.0.zh_CN.md
@@ -1,8 +1,6 @@
 # v2.0 - TBD
 
-# v2.0.0-RC 2024年3月25日
-
-## Added
+# v2.0.0-RC 
 
 - [#53](https://github.com/mineadmin/components/pull/53) 拆分组件 http-server
 - [#55](https://github.com/mineadmin/components/pull/55) 拆分优化组件 crontab
@@ -10,3 +8,4 @@
 - [#58](https://github.com/mineadmin/components/pull/58) 新增基础的 安全认证组件
 - [#59](https://github.com/mineadmin/components/pull/59) 添加安全访问控制组件
 - [#61](https://github.com/mineadmin/components/pull/61) 为导出 path 属性提供关联访问方式
+- [#64](https://github.com/mineadmin/components/pull/64) 修复表名为前缀_表名(s)这种复数形式的情况下无法生成model

--- a/src/mine-core/src/Command/Creater/CreateModel.php
+++ b/src/mine-core/src/Command/Creater/CreateModel.php
@@ -73,6 +73,9 @@ class CreateModel extends MineCommand
                 if (preg_match(sprintf('/%s(\\b|_[a-zA-Z0-9]+)/i', $module), $tmp)) {
                     $tableList[] = $tmp;
                 }
+                if ($tmp === $table) {
+                    $tableList[] = $tmp;
+                }
             }
 
             if (! empty($table)) {


### PR DESCRIPTION
修复表名为前缀_表名(s)这种复数形式的情况下无法生成model