### PR TITLE
feat(MineExcel): 新增按照属性在代码中的顺序排序方案

### DIFF
--- a/src/office/src/Excel/PhpOffice.php
+++ b/src/office/src/Excel/PhpOffice.php
@@ -59,16 +59,18 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
                 // 获取表头
                 // 获取表头，假设表头在第一行
                 $headerRow = $sheet->getActiveSheet()->getRowIterator(1, 1)->current();
-                foreach ($headerRow->getCellIterator('A', $endCell) as $index=> $item) {
-                    $propertyIndex = ord($index) - 65;; // 获得列索引
+                foreach ($headerRow->getCellIterator('A', $endCell) as $index => $item) {
+                    $propertyIndex = ord($index) - 65;
+                    ; // 获得列索引
                     $value = trim($item->getFormattedValue());
                     $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
                 }
                 // 读取数据，从第二行开始
                 foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
                     $temp = [];
-                    foreach ($row->getCellIterator('A', $endCell) as $index=> $item) {
-                        $propertyIndex = ord($index) - 65;; // 获得列索引
+                    foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
+                        $propertyIndex = ord($index) - 65;
+                        ; // 获得列索引
                         if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
                             $temp[$headerMap[$propertyIndex]] = trim($item->getFormattedValue()); // 映射表头标题到对应值
                         }
@@ -115,13 +117,13 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
             $style = $sheet->getStyle($headerColumn)->getFont()->setBold(true);
             $columnDimension = $sheet->getColumnDimension($headerColumn[0]);
 
-            empty($item['width']) ? $columnDimension->setAutoSize(true) : $columnDimension->setWidth((float) $item['width']);
+            empty($item['width']) ? $columnDimension->setAutoSize(true) : $columnDimension->setWidth((float)$item['width']);
 
             empty($item['align']) || $sheet->getStyle($headerColumn)->getAlignment()->setHorizontal($item['align']);
 
             empty($item['headColor']) || $style->setColor(new Color(str_replace('#', '', $item['headColor'])));
 
-            if (! empty($item['headBgColor'])) {
+            if (!empty($item['headBgColor'])) {
                 $sheet->getStyle($headerColumn)->getFill()
                     ->setFillType(Fill::FILL_SOLID)
                     ->getStartColor()->setARGB(str_replace('#', '', $item['headBgColor']));
@@ -147,24 +149,24 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
                         }
                     }
 
-                    if (! empty($annotation['dictName'])) {
+                    if (!empty($annotation['dictName'])) {
                         $sheet->setCellValue($columnRow, $annotation['dictName'][$value]);
-                    } elseif (! empty($annotation['path'])) {
+                    } elseif (!empty($annotation['path'])) {
                         $sheet->setCellValue($columnRow, Arr::get($items, $annotation['path']));
-                    } elseif (! empty($annotation['dictData'])) {
+                    } elseif (!empty($annotation['dictData'])) {
                         $sheet->setCellValue($columnRow, $annotation['dictData'][$value]);
-                    } elseif (! empty($this->dictData[$name])) {
+                    } elseif (!empty($this->dictData[$name])) {
                         $sheet->setCellValue($columnRow, $this->dictData[$name][$value] ?? '');
                     } else {
                         $sheet->setCellValue($columnRow, $value . "\t");
                     }
 
-                    if (! empty($item['color'])) {
+                    if (!empty($item['color'])) {
                         $sheet->getStyle($columnRow)->getFont()
                             ->setColor(new Color(str_replace('#', '', $annotation['color'])));
                     }
 
-                    if (! empty($item['bgColor'])) {
+                    if (!empty($item['bgColor'])) {
                         $sheet->getStyle($columnRow)->getFill()
                             ->setFillType(Fill::FILL_SOLID)
                             ->getStartColor()->setARGB(str_replace('#', '', $annotation['bgColor']));

--- a/src/office/src/Excel/PhpOffice.php
+++ b/src/office/src/Excel/PhpOffice.php
@@ -69,8 +69,7 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
         foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
             $temp = [];
             foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
-                $propertyIndex = ord($index) - 65;
-                ; // 获得列索引
+                $propertyIndex = ord($index) - 65; // 获得列索引
                 if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
                     $temp[$headerMap[$propertyIndex]] = trim($item->getFormattedValue()); // 映射表头标题到对应值
                 }

--- a/src/office/src/Excel/PhpOffice.php
+++ b/src/office/src/Excel/PhpOffice.php
@@ -29,57 +29,6 @@ use Psr\Http\Message\ResponseInterface;
 
 class PhpOffice extends MineExcel implements ExcelPropertyInterface
 {
-
-    private function getDataByIndex($sheet, $endCell): array
-    {
-        $data = [];
-        foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
-            $temp = [];
-            foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
-                $propertyIndex = ord($index) - 65;
-                if (isset($this->property[$propertyIndex])) {
-                    $temp[$this->property[$propertyIndex]['name']] = $item->getFormattedValue();
-                }
-            }
-            if (! empty($temp)) {
-                $data[] = $temp;
-            }
-        }
-        return $data;
-    }
-    private function getDataByText($sheet, $endCell): array
-    {
-        $data = [];
-        // 获取展示名称到字段名的映射关系
-        $fieldMap = [];
-        foreach ($this->property as $item) {
-            $fieldMap[trim($item['value'])] = $item['name'];
-        }
-
-        $headerMap = [];
-        // 获取表头
-        // 获取表头，假设表头在第一行
-        $headerRow = $sheet->getActiveSheet()->getRowIterator(1, 1)->current();
-        foreach ($headerRow->getCellIterator('A', $endCell) as $index => $item) {
-            $propertyIndex = ord($index) - 65; // 获得列索引
-            $value = trim($item->getFormattedValue());
-            $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
-        }
-        // 读取数据，从第二行开始
-        foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
-            $temp = [];
-            foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
-                $propertyIndex = ord($index) - 65; // 获得列索引
-                if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
-                    $temp[$headerMap[$propertyIndex]] = trim($item->getFormattedValue()); // 映射表头标题到对应值
-                }
-            }
-            $data[] = $temp;
-        }
-        return $data;
-    }
-
-
     /**
      * 导入.
      * @throws Exception
@@ -145,13 +94,13 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
             $style = $sheet->getStyle($headerColumn)->getFont()->setBold(true);
             $columnDimension = $sheet->getColumnDimension($headerColumn[0]);
 
-            empty($item['width']) ? $columnDimension->setAutoSize(true) : $columnDimension->setWidth((float)$item['width']);
+            empty($item['width']) ? $columnDimension->setAutoSize(true) : $columnDimension->setWidth((float) $item['width']);
 
             empty($item['align']) || $sheet->getStyle($headerColumn)->getAlignment()->setHorizontal($item['align']);
 
             empty($item['headColor']) || $style->setColor(new Color(str_replace('#', '', $item['headColor'])));
 
-            if (!empty($item['headBgColor'])) {
+            if (! empty($item['headBgColor'])) {
                 $sheet->getStyle($headerColumn)->getFill()
                     ->setFillType(Fill::FILL_SOLID)
                     ->getStartColor()->setARGB(str_replace('#', '', $item['headBgColor']));
@@ -177,24 +126,24 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
                         }
                     }
 
-                    if (!empty($annotation['dictName'])) {
+                    if (! empty($annotation['dictName'])) {
                         $sheet->setCellValue($columnRow, $annotation['dictName'][$value]);
-                    } elseif (!empty($annotation['path'])) {
+                    } elseif (! empty($annotation['path'])) {
                         $sheet->setCellValue($columnRow, Arr::get($items, $annotation['path']));
-                    } elseif (!empty($annotation['dictData'])) {
+                    } elseif (! empty($annotation['dictData'])) {
                         $sheet->setCellValue($columnRow, $annotation['dictData'][$value]);
-                    } elseif (!empty($this->dictData[$name])) {
+                    } elseif (! empty($this->dictData[$name])) {
                         $sheet->setCellValue($columnRow, $this->dictData[$name][$value] ?? '');
                     } else {
                         $sheet->setCellValue($columnRow, $value . "\t");
                     }
 
-                    if (!empty($item['color'])) {
+                    if (! empty($item['color'])) {
                         $sheet->getStyle($columnRow)->getFont()
                             ->setColor(new Color(str_replace('#', '', $annotation['color'])));
                     }
 
-                    if (!empty($item['bgColor'])) {
+                    if (! empty($item['bgColor'])) {
                         $sheet->getStyle($columnRow)->getFill()
                             ->setFillType(Fill::FILL_SOLID)
                             ->getStartColor()->setARGB(str_replace('#', '', $annotation['bgColor']));
@@ -228,4 +177,53 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
         }
     }
 
+    private function getDataByIndex($sheet, $endCell): array
+    {
+        $data = [];
+        foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
+            $temp = [];
+            foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
+                $propertyIndex = ord($index) - 65;
+                if (isset($this->property[$propertyIndex])) {
+                    $temp[$this->property[$propertyIndex]['name']] = $item->getFormattedValue();
+                }
+            }
+            if (! empty($temp)) {
+                $data[] = $temp;
+            }
+        }
+        return $data;
+    }
+
+    private function getDataByText($sheet, $endCell): array
+    {
+        $data = [];
+        // 获取展示名称到字段名的映射关系
+        $fieldMap = [];
+        foreach ($this->property as $item) {
+            $fieldMap[trim($item['value'])] = $item['name'];
+        }
+
+        $headerMap = [];
+        // 获取表头
+        // 获取表头，假设表头在第一行
+        $headerRow = $sheet->getActiveSheet()->getRowIterator(1, 1)->current();
+        foreach ($headerRow->getCellIterator('A', $endCell) as $index => $item) {
+            $propertyIndex = ord($index) - 65; // 获得列索引
+            $value = trim($item->getFormattedValue());
+            $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
+        }
+        // 读取数据，从第二行开始
+        foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
+            $temp = [];
+            foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
+                $propertyIndex = ord($index) - 65; // 获得列索引
+                if (! empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
+                    $temp[$headerMap[$propertyIndex]] = trim($item->getFormattedValue()); // 映射表头标题到对应值
+                }
+            }
+            $data[] = $temp;
+        }
+        return $data;
+    }
 }

--- a/src/office/src/Excel/PhpOffice.php
+++ b/src/office/src/Excel/PhpOffice.php
@@ -29,6 +29,58 @@ use Psr\Http\Message\ResponseInterface;
 
 class PhpOffice extends MineExcel implements ExcelPropertyInterface
 {
+
+    private function getDataByIndex($sheet, $endCell): array
+    {
+        $data = [];
+        foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
+            $temp = [];
+            foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
+                $propertyIndex = ord($index) - 65;
+                if (isset($this->property[$propertyIndex])) {
+                    $temp[$this->property[$propertyIndex]['name']] = $item->getFormattedValue();
+                }
+            }
+            if (! empty($temp)) {
+                $data[] = $temp;
+            }
+        }
+        return $data;
+    }
+    private function getDataByText($sheet, $endCell): array
+    {
+        $data = [];
+        // 获取展示名称到字段名的映射关系
+        $fieldMap = [];
+        foreach ($this->property as $item) {
+            $fieldMap[trim($item['value'])] = $item['name'];
+        }
+
+        $headerMap = [];
+        // 获取表头
+        // 获取表头，假设表头在第一行
+        $headerRow = $sheet->getActiveSheet()->getRowIterator(1, 1)->current();
+        foreach ($headerRow->getCellIterator('A', $endCell) as $index => $item) {
+            $propertyIndex = ord($index) - 65; // 获得列索引
+            $value = trim($item->getFormattedValue());
+            $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
+        }
+        // 读取数据，从第二行开始
+        foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
+            $temp = [];
+            foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
+                $propertyIndex = ord($index) - 65;
+                ; // 获得列索引
+                if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
+                    $temp[$headerMap[$propertyIndex]] = trim($item->getFormattedValue()); // 映射表头标题到对应值
+                }
+            }
+            $data[] = $temp;
+        }
+        return $data;
+    }
+
+
     /**
      * 导入.
      * @throws Exception
@@ -49,33 +101,10 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
             $sheet = $reader->load($tempFilePath);
             $endCell = isset($this->property) ? $this->getColumnIndex(count($this->property)) : null;
             try {
-                // 获取展示名称到字段名的映射关系
-                $fieldMap = [];
-                foreach ($this->property as $item) {
-                    $fieldMap[trim($item['value'])] = $item['name'];
-                }
-
-                $headerMap = [];
-                // 获取表头
-                // 获取表头，假设表头在第一行
-                $headerRow = $sheet->getActiveSheet()->getRowIterator(1, 1)->current();
-                foreach ($headerRow->getCellIterator('A', $endCell) as $index => $item) {
-                    $propertyIndex = ord($index) - 65;
-                    ; // 获得列索引
-                    $value = trim($item->getFormattedValue());
-                    $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
-                }
-                // 读取数据，从第二行开始
-                foreach ($sheet->getActiveSheet()->getRowIterator(2) as $row) {
-                    $temp = [];
-                    foreach ($row->getCellIterator('A', $endCell) as $index => $item) {
-                        $propertyIndex = ord($index) - 65;
-                        ; // 获得列索引
-                        if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
-                            $temp[$headerMap[$propertyIndex]] = trim($item->getFormattedValue()); // 映射表头标题到对应值
-                        }
-                    }
-                    $data[] = $temp;
+                if ($this->orderByIndex) {
+                    $data = $this->getDataByIndex($sheet, $endCell);
+                } else {
+                    $data = $this->getDataByText($sheet, $endCell);
                 }
                 unlink($tempFilePath);
             } catch (\Throwable $e) {
@@ -199,4 +228,5 @@ class PhpOffice extends MineExcel implements ExcelPropertyInterface
             yield $yield;
         }
     }
+
 }

--- a/src/office/src/Excel/XlsWriter.php
+++ b/src/office/src/Excel/XlsWriter.php
@@ -37,52 +37,6 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
         return $xlsxObject->openFile($tempFileName)->openSheet()->getSheetData();
     }
 
-    private function getDataByIndex($data)
-    {
-        unset($data[0]);
-        $importData = [];
-        foreach ($data as $item) {
-            $tmp = [];
-            foreach ($item as $key => $value) {
-                $tmp[$this->property[$key]['name']] = (string) $value;
-            }
-            $importData[] = $tmp;
-        }
-        return $importData;
-    }
-    private function getDataByText($data): array
-    {
-        $importData = [];
-        // 获取展示名称到字段名的映射关系
-        $fieldMap = [];
-        foreach ($this->property as $item) {
-            $fieldMap[trim($item['value'])] = $item['name'];
-        }
-
-        $headerMap = [];
-        // 获取表头
-        foreach ($data[0] as $index => $value) {
-            $propertyIndex = $index; // 获得列索引
-            $value = trim((string)$value);
-            $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
-        }
-
-        // 读取数据，从第二行开始
-        unset($data[0]);
-        foreach ($data as $row) {
-            $temp = [];
-            foreach ($row as $index => $value) {
-                $propertyIndex = $index; // 获得列索引
-                if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
-                    $temp[$headerMap[$propertyIndex]] = trim((string)$value); // 映射表头标题到对应值
-                }
-            }
-            if (!empty($temp)) {
-                $importData[] = $temp;
-            }
-        }
-        return $importData;
-    }
     /**
      * 导入数据.
      * @throws ContainerExceptionInterface
@@ -186,13 +140,13 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
             foreach ($this->property as $property) {
                 foreach ($item as $name => $value) {
                     if ($property['name'] == $name) {
-                        if (!empty($property['dictName'])) {
+                        if (! empty($property['dictName'])) {
                             $yield[] = $property['dictName'][$value];
-                        } elseif (!empty($property['dictData'])) {
+                        } elseif (! empty($property['dictData'])) {
                             $yield[] = $property['dictData'][$value];
-                        } elseif (!empty($property['path'])) {
+                        } elseif (! empty($property['path'])) {
                             $yield[] = Arr::get($item, $property['path']);
-                        } elseif (!empty($this->dictData[$name])) {
+                        } elseif (! empty($this->dictData[$name])) {
                             $yield[] = $this->dictData[$name][$value] ?? '';
                         } else {
                             $yield[] = $value;
@@ -221,5 +175,51 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
         return $res;
     }
 
+    private function getDataByIndex($data)
+    {
+        unset($data[0]);
+        $importData = [];
+        foreach ($data as $item) {
+            $tmp = [];
+            foreach ($item as $key => $value) {
+                $tmp[$this->property[$key]['name']] = (string) $value;
+            }
+            $importData[] = $tmp;
+        }
+        return $importData;
+    }
 
+    private function getDataByText($data): array
+    {
+        $importData = [];
+        // 获取展示名称到字段名的映射关系
+        $fieldMap = [];
+        foreach ($this->property as $item) {
+            $fieldMap[trim($item['value'])] = $item['name'];
+        }
+
+        $headerMap = [];
+        // 获取表头
+        foreach ($data[0] as $index => $value) {
+            $propertyIndex = $index; // 获得列索引
+            $value = trim((string) $value);
+            $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
+        }
+
+        // 读取数据，从第二行开始
+        unset($data[0]);
+        foreach ($data as $row) {
+            $temp = [];
+            foreach ($row as $index => $value) {
+                $propertyIndex = $index; // 获得列索引
+                if (! empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
+                    $temp[$headerMap[$propertyIndex]] = trim((string) $value); // 映射表头标题到对应值
+                }
+            }
+            if (! empty($temp)) {
+                $importData[] = $temp;
+            }
+        }
+        return $importData;
+    }
 }

--- a/src/office/src/Excel/XlsWriter.php
+++ b/src/office/src/Excel/XlsWriter.php
@@ -64,9 +64,9 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
 
             $headerMap = [];
             // 获取表头
-            foreach ($data[0] as $index=> $value) {
+            foreach ($data[0] as $index => $value) {
                 $propertyIndex = $index; // 获得列索引
-                $value = trim((string) $value);
+                $value = trim((string)$value);
                 $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
             }
 
@@ -74,10 +74,10 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
             unset($data[0]);
             foreach ($data as $row) {
                 $temp = [];
-                foreach ($row as $index=> $value) {
+                foreach ($row as $index => $value) {
                     $propertyIndex = $index; // 获得列索引
                     if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
-                        $temp[$headerMap[$propertyIndex]] = trim((string) $value); // 映射表头标题到对应值
+                        $temp[$headerMap[$propertyIndex]] = trim((string)$value); // 映射表头标题到对应值
                     }
                 }
                 if (!empty($temp)) {
@@ -165,13 +165,13 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
             foreach ($this->property as $property) {
                 foreach ($item as $name => $value) {
                     if ($property['name'] == $name) {
-                        if (! empty($property['dictName'])) {
+                        if (!empty($property['dictName'])) {
                             $yield[] = $property['dictName'][$value];
-                        } elseif (! empty($property['dictData'])) {
+                        } elseif (!empty($property['dictData'])) {
                             $yield[] = $property['dictData'][$value];
-                        } elseif (! empty($property['path'])) {
+                        } elseif (!empty($property['path'])) {
                             $yield[] = Arr::get($item, $property['path']);
-                        } elseif (! empty($this->dictData[$name])) {
+                        } elseif (!empty($this->dictData[$name])) {
                             $yield[] = $this->dictData[$name][$value] ?? '';
                         } else {
                             $yield[] = $value;

--- a/src/office/src/Excel/XlsWriter.php
+++ b/src/office/src/Excel/XlsWriter.php
@@ -53,15 +53,36 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
             file_put_contents($tempFilePath, $file->getStream()->getContents());
             $xlsxObject = new Excel(['path' => BASE_PATH . '/runtime/']);
             $data = $xlsxObject->openFile($tempFileName)->openSheet()->getSheetData();
-            unset($data[0]);
 
             $importData = [];
-            foreach ($data as $item) {
-                $tmp = [];
-                foreach ($item as $key => $value) {
-                    $tmp[$this->property[$key]['name']] = (string) $value;
+
+            // 获取展示名称到字段名的映射关系
+            $fieldMap = [];
+            foreach ($this->property as $item) {
+                $fieldMap[trim($item['value'])] = $item['name'];
+            }
+
+            $headerMap = [];
+            // 获取表头
+            foreach ($data[0] as $index=> $value) {
+                $propertyIndex = $index; // 获得列索引
+                $value = trim((string) $value);
+                $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
+            }
+
+            // 读取数据，从第二行开始
+            unset($data[0]);
+            foreach ($data as $row) {
+                $temp = [];
+                foreach ($row as $index=> $value) {
+                    $propertyIndex = $index; // 获得列索引
+                    if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
+                        $temp[$headerMap[$propertyIndex]] = trim((string) $value); // 映射表头标题到对应值
+                    }
                 }
-                $importData[] = $tmp;
+                if (!empty($temp)) {
+                    $importData[] = $temp;
+                }
             }
 
             if ($closure instanceof \Closure) {

--- a/src/office/src/MineExcel.php
+++ b/src/office/src/MineExcel.php
@@ -67,7 +67,7 @@ abstract class MineExcel
         }
 
         foreach ($this->annotationMate['_p'] as $name => $mate) {
-            $this->property[$mate[self::ANNOTATION_NAME]->index] = [
+            $tmp = [
                 'name' => $name,
                 'value' => $mate[self::ANNOTATION_NAME]->value,
                 'width' => $mate[self::ANNOTATION_NAME]->width ?? null,
@@ -80,6 +80,11 @@ abstract class MineExcel
                 'dictName' => empty($mate[self::ANNOTATION_NAME]->dictName) ? null : $this->getDictData($mate[self::ANNOTATION_NAME]->dictName),
                 'path' => $mate[self::ANNOTATION_NAME]->path ?? null,
             ];
+            if (isset($mate[self::ANNOTATION_NAME]->index)){
+                $this->property[$mate[self::ANNOTATION_NAME]->index] = $tmp;
+            }else{
+                $this->property[] = $tmp;
+            }
         }
         ksort($this->property);
     }

--- a/src/office/src/MineExcel.php
+++ b/src/office/src/MineExcel.php
@@ -34,7 +34,7 @@ abstract class MineExcel
 
     public function __construct(string $dto)
     {
-        if (! (new $dto()) instanceof MineModelExcel) {
+        if (!(new $dto()) instanceof MineModelExcel) {
             throw new MineException('dto does not implement an interface of the MineModelExcel', 500);
         }
         $dtoObject = new $dto();
@@ -62,7 +62,7 @@ abstract class MineExcel
      */
     protected function parseProperty(): void
     {
-        if (empty($this->annotationMate) || ! isset($this->annotationMate['_c'])) {
+        if (empty($this->annotationMate) || !isset($this->annotationMate['_c'])) {
             throw new MineException('dto annotation info is empty', 500);
         }
 
@@ -80,9 +80,9 @@ abstract class MineExcel
                 'dictName' => empty($mate[self::ANNOTATION_NAME]->dictName) ? null : $this->getDictData($mate[self::ANNOTATION_NAME]->dictName),
                 'path' => $mate[self::ANNOTATION_NAME]->path ?? null,
             ];
-            if (isset($mate[self::ANNOTATION_NAME]->index)){
+            if (isset($mate[self::ANNOTATION_NAME]->index)) {
                 $this->property[$mate[self::ANNOTATION_NAME]->index] = $tmp;
-            }else{
+            } else {
                 $this->property[] = $tmp;
             }
         }
@@ -117,8 +117,8 @@ abstract class MineExcel
     {
         $data = [];
         foreach (container()
-            ->get(DictDataServiceInterface::class)
-            ->getList(['code' => $dictName]) as $item) {
+                     ->get(DictDataServiceInterface::class)
+                     ->getList(['code' => $dictName]) as $item) {
             $data[$item['key']] = $item['title'];
         }
 

--- a/src/office/src/MineExcel.php
+++ b/src/office/src/MineExcel.php
@@ -35,13 +35,13 @@ abstract class MineExcel
     /**
      * 是否通过index进行排序
      * 否则使用属性在代码中的位置进行排序
-     * 同时影响 导入和导出
+     * 同时影响 导入和导出.
      */
     protected ?bool $orderByIndex;
 
     public function __construct(string $dto)
     {
-        if (!(new $dto()) instanceof MineModelExcel) {
+        if (! (new $dto()) instanceof MineModelExcel) {
             throw new MineException('dto does not implement an interface of the MineModelExcel', 500);
         }
         $dtoObject = new $dto();
@@ -69,7 +69,7 @@ abstract class MineExcel
      */
     protected function parseProperty(): void
     {
-        if (empty($this->annotationMate) || !isset($this->annotationMate['_c'])) {
+        if (empty($this->annotationMate) || ! isset($this->annotationMate['_c'])) {
             throw new MineException('dto annotation info is empty', 500);
         }
 
@@ -130,8 +130,8 @@ abstract class MineExcel
     {
         $data = [];
         foreach (container()
-                     ->get(DictDataServiceInterface::class)
-                     ->getList(['code' => $dictName]) as $item) {
+            ->get(DictDataServiceInterface::class)
+            ->getList(['code' => $dictName]) as $item) {
             $data[$item['key']] = $item['title'];
         }
 


### PR DESCRIPTION
新增按照属性在代码中的顺序排序方案 兼容index方案
有以下问题可能需要解决:
如果只有部分字段定义了index 分以下情况
    情况1:属性排在第3个  如果都不加index  属性默认的键就是2,如果这个元素加了index=1  则会把键为1的元素覆盖
    情况2:属性排在第3个  如果都不加index  属性默认的键就是2,如果这个元素加了index=100 则从这个元素开始的键名是从100开始递增,目前未发现副作用
建议解决方案:仅允许全部都添加index或者全部都不添加index  非正常情况都报错提示