### PR TITLE
feat(excel): 通过excel表头的中文和dto的value匹配,获取的字段名称和值的映射关系

### DIFF
--- a/src/office/src/Excel/XlsWriter.php
+++ b/src/office/src/Excel/XlsWriter.php
@@ -53,15 +53,36 @@ class XlsWriter extends MineExcel implements ExcelPropertyInterface
             file_put_contents($tempFilePath, $file->getStream()->getContents());
             $xlsxObject = new Excel(['path' => BASE_PATH . '/runtime/']);
             $data = $xlsxObject->openFile($tempFileName)->openSheet()->getSheetData();
-            unset($data[0]);
 
             $importData = [];
-            foreach ($data as $item) {
-                $tmp = [];
-                foreach ($item as $key => $value) {
-                    $tmp[$this->property[$key]['name']] = (string) $value;
+
+            // 获取展示名称到字段名的映射关系
+            $fieldMap = [];
+            foreach ($this->property as $item) {
+                $fieldMap[trim($item['value'])] = $item['name'];
+            }
+
+            $headerMap = [];
+            // 获取表头
+            foreach ($data[0] as $index=> $value) {
+                $propertyIndex = $index; // 获得列索引
+                $value = trim((string) $value);
+                $headerMap[$propertyIndex] = $fieldMap[$value] ?? null; // 获取表头值
+            }
+
+            // 读取数据，从第二行开始
+            unset($data[0]);
+            foreach ($data as $row) {
+                $temp = [];
+                foreach ($row as $index=> $value) {
+                    $propertyIndex = $index; // 获得列索引
+                    if (!empty($headerMap[$propertyIndex])) { // 确保列索引存在于表头数组中
+                        $temp[$headerMap[$propertyIndex]] = trim((string) $value); // 映射表头标题到对应值
+                    }
                 }
-                $importData[] = $tmp;
+                if (!empty($temp)) {
+                    $importData[] = $temp;
+                }
             }
 
             if ($closure instanceof \Closure) {


### PR DESCRIPTION
import方法不依赖excel表格中的index位置 仅依赖于表头名称
通过表格表头的中文和dto中excel注解的value值做匹配获得dto的字段名称
