### PR TITLE
移除读取详情接口模版代码未定义变量

### DIFF
--- a/src/mine-generator/Stubs/Api/read.stub
+++ b/src/mine-generator/Stubs/Api/read.stub
@@ -6,7 +6,6 @@
   read (id) {
     return request({
       url: '{REQUEST_ROUTE}/read/' + id,
-      method: 'get',
-      data
+      method: 'get'
     })
   },


### PR DESCRIPTION
生成前端代码读取详情接口，存在未定义变量。该操作将其移除。