### PR TITLE
Update InstallProjectCommand.php

### DIFF
--- a/src/mine-core/src/Command/InstallProjectCommand.php
+++ b/src/mine-core/src/Command/InstallProjectCommand.php
@@ -154,11 +154,11 @@ class InstallProjectCommand extends MineCommand
             'user_id' => $superAdminId,
             'role_id' => $superRoleId,
         ]);
-        file_put_contents(BASE_PATH . '/.env', <<<ENV
+        $envConfig = <<<ENV
 SUPER_ADMIN = {$superAdminId}
 ADMIN_ROLE = {$superRoleId}
-ENV
-            , FILE_APPEND);
+ENV;
+        file_put_contents(BASE_PATH . '/.env', $envConfig, FILE_APPEND);
     }
 
     protected function finish(): void


### PR DESCRIPTION
原先写法，会导致mac系统中，env文件写入缺失 SUPER_ADMIN = 1，可能是换行或空格的因素影响