### PR TITLE
Add PluginNotFoundException and make Plugin::read more safe

### DIFF
--- a/src/AppStore/src/Exception/PluginNotFoundException.php
+++ b/src/AppStore/src/Exception/PluginNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+
+namespace Mine\AppStore\Exception;
+
+class PluginNotFoundException extends \Exception
+{
+    public function __construct($path)
+    {
+        parent::__construct(sprintf('The given directory [%s] is not a valid plugin, probably because it is already installed or the directory is not standardized.', $path));
+    }
+}


### PR DESCRIPTION
Add PluginNotFoundException and refactor Plugin class

• Add PluginNotFoundException in AppStore to handle missing plugins
• Modify Plugin::load() to throw PluginNotFoundException when plugin is not found
• Add tests for PluginNotFoundException and updated Plugin methods
