### PR TITLE
Remove mine.json validation

### DIFF
--- a/src/AppStore/src/Plugin.php
+++ b/src/AppStore/src/Plugin.php
@@ -415,6 +415,6 @@ class Plugin
             $loader->addClassMap($mineInfo['composer']['classMap']);
         }
 
-        self::checkPlugin($mine);
+        // self::checkPlugin($mine);
     }
 }


### PR DESCRIPTION
Removed the validation check for mine.json as it is no longer required in the current workflow. This change simplifies the process and reduces unnecessary complexity.