### PR TITLE
fix(jwt-auth): use public key for token validation

### DIFF
--- a/src/jwt-auth/src/JWT.php
+++ b/src/jwt-auth/src/JWT.php
@@ -129,7 +129,7 @@ class JWT extends AbstractJWT
                 throw new TokenValidException('Token authentication does not pass', 401);
             }
 
-            if ($validate && ! $this->validateToken($signer, $this->getKey($config), $token)) {
+            if ($validate && ! $this->validateToken($signer, $this->getKey($config, 'public'), $token)) {
                 throw new TokenValidException('Token authentication does not pass', 401);
             }
 

--- a/src/mine-core/src/Traits/MapperTrait.php
+++ b/src/mine-core/src/Traits/MapperTrait.php
@@ -231,7 +231,7 @@ trait MapperTrait
     /**
      * 过滤新增或写入不存在的字段.
      */
-    public function filterExecuteAttributes(array &$data, bool $removePk = false): void
+    public function filterExecuteAttributes(array $data, bool $removePk = false): array
     {
         $model = new $this->model();
         $attrs = $model->getFillable();
@@ -244,6 +244,8 @@ trait MapperTrait
             unset($data[$model->getKeyName()]);
         }
         $model = null;
+
+        return $data;
     }
 
     /**
@@ -251,8 +253,7 @@ trait MapperTrait
      */
     public function save(array $data): mixed
     {
-        $this->filterExecuteAttributes($data, $this->getModel()->incrementing);
-        $model = $this->model::create($data);
+        $model = $this->model::create($this->filterExecuteAttributes($data, $this->getModel()->incrementing));
         return $model->{$model->getKeyName()};
     }
 
@@ -315,8 +316,7 @@ trait MapperTrait
      */
     public function update(mixed $id, array $data): bool
     {
-        $this->filterExecuteAttributes($data, true);
-        return $this->model::find($id)->update($data) > 0;
+        return $this->model::find($id)->update($this->filterExecuteAttributes($data, true)) > 0;
     }
 
     /**
@@ -324,8 +324,7 @@ trait MapperTrait
      */
     public function updateByCondition(array $condition, array $data): bool
     {
-        $this->filterExecuteAttributes($data, true);
-        return $this->model::query()->where($condition)->update($data) > 0;
+        return $this->model::query()->where($condition)->update($this->filterExecuteAttributes($data, true)) > 0;
     }
 
     /**


### PR DESCRIPTION
fix(jwt-auth): use public key for token 

Change the key retrieval method to use the 'public' key option when validating tokens
in the JWT class. This ensures that token validation utilizes the appropriate key type,
matching the intended security configuration for JWT authentication.

Revert "fix: filterExecuteAttributes 地址引用导致aop后变量指针错误的问题" 