### PR TITLE
fix(jwt-auth): use public key for token validation (#104)

### DIFF
--- a/src/jwt-auth/src/JWT.php
+++ b/src/jwt-auth/src/JWT.php
@@ -129,7 +129,7 @@ class JWT extends AbstractJWT
                 throw new TokenValidException('Token authentication does not pass', 401);
             }
 
-            if ($validate && ! $this->validateToken($signer, $this->getKey($config), $token)) {
+            if ($validate && ! $this->validateToken($signer, $this->getKey($config, 'public'), $token)) {
                 throw new TokenValidException('Token authentication does not pass', 401);
             }
 


### PR DESCRIPTION
Change the key retrieval method to use the 'public' key option when validating tokens in the JWT class. This ensures that token validation utilizes the appropriate key type, matching the intended security configuration for JWT authentication.