### PR TITLE
Fixed: MapperTrait中recovery不能触发hyperf模型事件 restoring 和 restored 钩子

### DIFF
--- a/src/AppStore/src/Plugin.php
+++ b/src/AppStore/src/Plugin.php
@@ -411,6 +411,7 @@ class Plugin
      * usege:
      *      t('plugin.mine-admin.app-store.app_not_installed')
      *      pt('mine-admin.app-store', app_not_installed').
+     * @param mixed $lang
      */
     public static function getPluginLanguages($lang): array
     {

--- a/src/mine-core/src/Traits/MapperTrait.php
+++ b/src/mine-core/src/Traits/MapperTrait.php
@@ -345,7 +345,10 @@ trait MapperTrait
      */
     public function recovery(array $ids): bool
     {
-        $this->model::withTrashed()->whereIn((new $this->model())->getKeyName(), $ids)->restore();
+        foreach ($ids as $id) {
+            $model = $this->model::withTrashed()->find($id);
+            $model && $model->restore();
+        }
         return true;
     }
 


### PR DESCRIPTION
issues: https://gitee.com/mineadmin/mineadmin/issues/IAKREW