### PR TITLE
feat(Jwt): add custom builder callback support

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -e
 if (( "$#" == 0 ))
 then

--- a/src/Jwt/AbstractJwt.php
+++ b/src/Jwt/AbstractJwt.php
@@ -35,26 +35,32 @@ abstract class AbstractJwt implements JwtInterface
         private readonly RefreshTokenConstraint $refreshTokenConstraint
     ) {}
 
-    public function builderRefreshToken(string $sub): UnencryptedToken
+    public function builderRefreshToken(string $sub, ?\Closure $callable = null): UnencryptedToken
     {
         return $this->getJwtFacade()->issue(
             $this->getSigner(),
             $this->getSigningKey(),
-            function (Builder $builder, \DateTimeImmutable $immutable) use ($sub) {
+            function (Builder $builder, \DateTimeImmutable $immutable) use ($sub, $callable) {
                 $builder = $builder->identifiedBy($sub);
                 $builder = $builder->expiresAt($this->getRefreshExpireAt($immutable));
+                if ($callable !== null) {
+                    $builder = $callable($builder);
+                }
                 return $builder->relatedTo('refresh');
             }
         );
     }
 
-    public function builderAccessToken(string $sub): UnencryptedToken
+    public function builderAccessToken(string $sub, ?\Closure $callable = null): UnencryptedToken
     {
         return $this->getJwtFacade()->issue(
             $this->getSigner(),
             $this->getSigningKey(),
-            function (Builder $builder, \DateTimeImmutable $immutable) use ($sub) {
+            function (Builder $builder, \DateTimeImmutable $immutable) use ($sub, $callable) {
                 $builder = $builder->identifiedBy($sub);
+                if ($callable !== null) {
+                    $builder = $callable($builder);
+                }
                 return $builder->expiresAt($this->getExpireAt($immutable));
             }
         );

--- a/src/Jwt/JwtInterface.php
+++ b/src/Jwt/JwtInterface.php
@@ -16,9 +16,9 @@ use Lcobucci\JWT\UnencryptedToken;
 
 interface JwtInterface
 {
-    public function builderAccessToken(string $sub): UnencryptedToken;
+    public function builderAccessToken(string $sub, ?\Closure $callable = null): UnencryptedToken;
 
-    public function builderRefreshToken(string $sub): UnencryptedToken;
+    public function builderRefreshToken(string $sub, ?\Closure $callable = null): UnencryptedToken;
 
     public function parserAccessToken(string $accessToken): UnencryptedToken;
 


### PR DESCRIPTION
- Update builderAccessToken and builderRefreshToken methods to accept an optional Closure
- The Closure allows custom modifications to the token builder
- This enhancement provides more flexibility for token creation