### PR TITLE
Fix crontab bug 0124

### DIFF
--- a/src/mine-core/src/Listener/ResumeExitCoordinatorListener.php
+++ b/src/mine-core/src/Listener/ResumeExitCoordinatorListener.php
@@ -18,7 +18,6 @@ use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Event\Annotation\Listener;
 use Hyperf\Event\Contract\ListenerInterface;
 
-#[Listener]
 class ResumeExitCoordinatorListener implements ListenerInterface
 {
     public function listen(): array


### PR DESCRIPTION
> 修复定时任务执行失败的问题 

> 复现步骤

1. 后台点击执行一次命令行类的定时任务，会导致worker的channel关闭；
2.使用注解Crontab的任务分发到该worker进程的时候，会因为channel关闭导致执行失败；

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to load plugin language files dynamically

- **Refactor**
	- Removed listener attribute from `ResumeExitCoordinatorListener`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->