### PR TITLE
refactor(ClientIp): standardize header names to lowercase

### DIFF
--- a/src/Support/Request/ClientIpRequestConstant.php
+++ b/src/Support/Request/ClientIpRequestConstant.php
@@ -34,11 +34,11 @@ final class ClientIpRequestConstant
     ];
 
     public const TRUSTED_HEADERS = [
-        self::HEADER_FORWARDED => 'HTTP_FORWARDED',
-        self::HEADER_X_FORWARDED_FOR => 'HTTP_X_FORWARDED_FOR',
-        self::HEADER_X_FORWARDED_HOST => 'HTTP_X_FORWARDED_HOST',
-        self::HEADER_X_FORWARDED_PROTO => 'HTTP_X_FORWARDED_PROTO',
-        self::HEADER_X_FORWARDED_PORT => 'HTTP_X_FORWARDED_PORT',
-        self::HEADER_X_FORWARDED_PREFIX => 'HTTP_X_FORWARDED_PREFIX',
+        self::HEADER_FORWARDED => 'forwarded',
+        self::HEADER_X_FORWARDED_FOR => 'x-forwarded-for',
+        self::HEADER_X_FORWARDED_HOST => 'x-forwarded-host',
+        self::HEADER_X_FORWARDED_PROTO => 'x-forwarded-proto',
+        self::HEADER_X_FORWARDED_PORT => 'x-forwarded-port',
+        self::HEADER_X_FORWARDED_PREFIX => 'x-forwarded-prefix',
     ];
 }

--- a/src/Support/Request/ClientIpRequestTrait.php
+++ b/src/Support/Request/ClientIpRequestTrait.php
@@ -49,7 +49,7 @@ trait ClientIpRequestTrait
      */
     public static function setTrustedProxies(array $proxies, int $trustedHeaderSet): void
     {
-        if (false !== $i = array_search('REMOTE_ADDR', $proxies, true)) {
+        if (false !== $i = array_search('remote_addr', $proxies, true)) {
             self::$isTrustedRemoteAddr = true;
         }
 
@@ -75,7 +75,7 @@ trait ClientIpRequestTrait
      */
     public function getClientIps(): array
     {
-        $ip = $this->server('REMOTE_ADDR');
+        $ip = $this->server('remote_addr');
 
         if (! $this->isFromTrustedProxy()) {
             return [$ip];
@@ -93,7 +93,7 @@ trait ClientIpRequestTrait
     public function isFromTrustedProxy(): bool
     {
         return (self::$trustedProxies
-        && IpUtils::checkIp($this->server('REMOTE_ADDR', ''), self::$trustedProxies))
+        && IpUtils::checkIp($this->server('remote_addr', ''), self::$trustedProxies))
         || self::isTrustedRemoteAddr();
     }
 

--- a/tests/Feature/Support/Request/ClientIpTest.php
+++ b/tests/Feature/Support/Request/ClientIpTest.php
@@ -75,10 +75,10 @@ function getRequestInstanceForClientIpTests(string $remoteAddr, ?string $httpFor
 {
     $swooleRequest = Mockery::mock(Swoole\Http\Request::class);
     $serverParams = [
-        'REMOTE_ADDR' => $remoteAddr,
+        'remote_addr' => $remoteAddr,
     ];
     if ($httpForwardedFor !== null) {
-        $serverParams['HTTP_X_FORWARDED_FOR'] = $httpForwardedFor;
+        $serverParams['x-forwarded-for'] = $httpForwardedFor;
     }
     $swooleRequest->server = $serverParams;
     $swooleRequest->header = $serverParams;
@@ -102,10 +102,10 @@ function getRequestInstanceForClientIpsForwardedTests(string $remoteAddr, ?strin
 {
     $swooleRequest = Mockery::mock(Swoole\Http\Request::class);
     $serverParams = [
-        'REMOTE_ADDR' => $remoteAddr,
+        'remote_addr' => $remoteAddr,
     ];
     if ($httpForwarded !== null) {
-        $serverParams['HTTP_FORWARDED'] = $httpForwarded;
+        $serverParams['forwarded'] = $httpForwarded;
     }
     $swooleRequest->server = $serverParams;
     $swooleRequest->header = $serverParams;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了客户端 IP 提取逻辑对请求头和参数名称大小写的处理，提高了兼容性和准确性。

- **测试**
  - 更新了相关测试用例以适配新的请求头和参数名称格式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->