### PR TITLE
refactor(UuidRequestIdProcessor): extract uuid setting logic to separate method

### DIFF
--- a/src/Crontab/src/Aspect/CrontabExecutorAspect.php
+++ b/src/Crontab/src/Aspect/CrontabExecutorAspect.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Mine\Crontab\Aspect;
 
+use Carbon\Carbon;
 use Hyperf\Crontab\Crontab;
 use Hyperf\Crontab\Strategy\Executor;
 use Hyperf\DbConnection\Db;
@@ -46,6 +47,7 @@ class CrontabExecutorAspect extends AbstractAspect
                     'target' => $callback,
                     'status' => $isSuccess ? 1 : 0,
                     'exception_info' => $throwable === null ? '' : $throwable->getMessage(),
+                    'created_at' => Carbon::now(),
                 ]);
         }
         return $proceedingJoinPoint->process();

--- a/src/Support/Logger/UuidRequestIdProcessor.php
+++ b/src/Support/Logger/UuidRequestIdProcessor.php
@@ -35,15 +35,16 @@ final class UuidRequestIdProcessor implements ProcessorInterface
             if ($requestId === null) {
                 $requestId = Context::get(self::REQUEST_ID, null, Coroutine::parentId());
                 if ($requestId !== null) {
-                    Context::set(self::REQUEST_ID, $requestId);
+                    self::setUuid($requestId);
+                    return $requestId;
                 }
             }
-            if ($requestId === null) {
-                $requestId = Uuid::uuid4()->toString();
-            }
-        } else {
-            $requestId = Context::set(self::REQUEST_ID, Uuid::uuid4()->toString());
         }
-        return $requestId;
+        return self::setUuid(Uuid::uuid4()->toString());
+    }
+
+    public static function setUuid(string $requestId): string
+    {
+        return Context::set(self::REQUEST_ID, $requestId);
     }
 }

--- a/src/Support/Logger/UuidRequestIdProcessor.php
+++ b/src/Support/Logger/UuidRequestIdProcessor.php
@@ -30,16 +30,18 @@ final class UuidRequestIdProcessor implements ProcessorInterface
 
     public static function getUuid(): string
     {
+        $requestId = Context::get(self::REQUEST_ID);
+        if ($requestId) {
+            return $requestId;
+        }
         if (Coroutine::inCoroutine()) {
-            $requestId = Context::get(self::REQUEST_ID);
-            if ($requestId === null) {
-                $requestId = Context::get(self::REQUEST_ID, null, Coroutine::parentId());
-                if ($requestId !== null) {
-                    self::setUuid($requestId);
-                    return $requestId;
-                }
+            $requestId = Context::get(self::REQUEST_ID, null, Coroutine::parentId());
+            if ($requestId !== null) {
+                self::setUuid($requestId);
+                return $requestId;
             }
         }
+
         return self::setUuid(Uuid::uuid4()->toString());
     }
 

--- a/tests/Support/UuidTest.php
+++ b/tests/Support/UuidTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of MineAdmin.
+ *
+ * @link     https://www.mineadmin.com
+ * @document https://doc.mineadmin.com
+ * @contact  root@imoi.cn
+ * @license  https://github.com/mineadmin/MineAdmin/blob/master/LICENSE
+ */
+use Hyperf\Coroutine\Coroutine;
+use Mine\Support\Logger\UuidRequestIdProcessor;
+
+test('testSetUuid', function () {
+    $uuid = UuidRequestIdProcessor::setUuid('1234567890');
+    $this->assertEquals('1234567890', $uuid);
+});
+
+test('testGetUuidInCoroutine', function () {
+    if (Coroutine::inCoroutine()) {
+        $uuid = UuidRequestIdProcessor::getUuid();
+        Coroutine::create(function () use ($uuid) {
+            $this->assertEquals($uuid, UuidRequestIdProcessor::getUuid());
+        });
+    } else {
+        Coroutine::create(function () {
+            $uuid = UuidRequestIdProcessor::getUuid();
+            Coroutine::create(function () use ($uuid) {
+                $this->assertEquals($uuid, UuidRequestIdProcessor::getUuid());
+            });
+        });
+    }
+});
+
+test('testAutoSetUuid', function () {
+    UuidRequestIdProcessor::setUuid('11233123');
+    $this->assertEquals('11233123', UuidRequestIdProcessor::getUuid());
+});
+
+test('testAutoSetUuidInCoroutine', function () {
+    Coroutine::create(function () {
+        UuidRequestIdProcessor::setUuid('11233123');
+        $this->assertEquals('11233123', UuidRequestIdProcessor::getUuid());
+    });
+});
+
+test('testAutoSetUuidInParent', function () {
+    Coroutine::create(function () {
+        UuidRequestIdProcessor::setUuid('11233123');
+        $this->assertEquals('11233123', UuidRequestIdProcessor::getUuid());
+        Coroutine::create(function () {
+            $this->assertEquals('11233123', UuidRequestIdProcessor::getUuid());
+        });
+    });
+});


### PR DESCRIPTION

- Move the logic for setting the UUID into a dedicated setUuid method to improve code reusability and maintainability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 优化了请求 ID 的获取和设置逻辑，使其在常规和协程环境下更加简洁高效。
* **测试**
  * 新增了针对请求 ID 处理器的单元测试，覆盖了协程内外的多种使用场景，确保功能一致性和稳定性。
* **新功能**
  * 在定时任务执行日志中新增创建时间字段，记录任务执行的具体时间。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->