### PR TITLE
fix(Plugin): update the database rollback for plugin uninstallation

### DIFF
--- a/src/AppStore/src/Plugin.php
+++ b/src/AppStore/src/Plugin.php
@@ -381,7 +381,7 @@ class Plugin
         $migrator = ApplicationContext::getContainer()->get(Migrator::class);
 
         // Perform migration rollback
-        $migrator->rollback($pluginPath . '/Database/Migrations');
+        $migrator->reset([$pluginPath . '/Database/Migrations']);
         // If the plugin exists in the web directory, perform the migration of the front-end files
         if (file_exists($pluginPath . '/web')) {
             $finder = Finder::create()


### PR DESCRIPTION
插件卸载时调用的数据库回滚rollback方法，在没有传参数options['step']时调用的获取迁移文件的方法为$this->repository->getLast()。
该方法实际找的为最后一个批次执行的迁移文件，执行了sql：select max(`batch`) as aggregate from `migrations`。
在后续回滚过程中，从数据库中查出来的迁移文件和当前卸载的插件的迁移文件可能会不匹配，回滚无效。

修改为reset方法会查整个migrations表，然后再回滚传入的目录路径中的迁移文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **优化**
  * 优化插件卸载时的数据库迁移回滚机制，提升卸载流程的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->