### PR TITLE
fix(CreateCommand): match the seeder directory when installing the plugin

### DIFF
--- a/src/AppStore/src/Command/CreateCommand.php
+++ b/src/AppStore/src/Command/CreateCommand.php
@@ -48,7 +48,7 @@ class CreateCommand extends AbstractCommand
             return AbstractCommand::FAILURE;
         }
         $createDirectors = [
-            $pluginPath, $pluginPath . '/src', $pluginPath . '/Database', $pluginPath . '/Database/Migrations', $pluginPath . '/Database/Seeder', $pluginPath . '/web',
+            $pluginPath, $pluginPath . '/src', $pluginPath . '/Database', $pluginPath . '/Database/Migrations', $pluginPath . '/Database/Seeders', $pluginPath . '/web',
         ];
         foreach ($createDirectors as $directory) {
             if (! mkdir($directory, 0o755, true) && ! is_dir($directory)) {


### PR DESCRIPTION
插件安装时执行的数据填充方法为$seeder->run($pluginPath . '/Database/Seeders')，修改创建插件模板的目录

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复问题**
  * 修正了插件安装过程中数据库种子文件目录的命名，从“Database/Seeder”更新为“Database/Seeders”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->