### PR TITLE
fix(AppStore/CreateCommand): correct namespace formatting and improve JSON output

### DIFF
--- a/src/AppStore/src/Command/CreateCommand.php
+++ b/src/AppStore/src/Command/CreateCommand.php
@@ -92,7 +92,7 @@ class CreateCommand extends AbstractCommand
             $output->composer = [
                 'require' => [],
                 'psr-4' => [
-                    '\\' . $namespace . '\\' => 'src',
+                    $namespace . '\\' => 'src',
                 ],
                 'installScript' => $namespace . '\InstallScript',
                 'uninstallScript' => $namespace . '\UninstallScript',
@@ -106,7 +106,7 @@ class CreateCommand extends AbstractCommand
                 ],
             ];
         }
-        $output = Json::encode($output);
+        $output = Json::encode($output, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT);
         file_put_contents($path . '/mine.json', $output);
         $this->output->success(\sprintf('%s 创建成功', $path . '/mine.json'));
     }

--- a/src/AppStore/src/Command/CreateCommand.php
+++ b/src/AppStore/src/Command/CreateCommand.php
@@ -43,8 +43,9 @@ class CreateCommand extends AbstractCommand
             return AbstractCommand::FAILURE;
         }
 
-        if (mb_substr_count($path, '/') !== 1) {
-            $this->output->error('The plug-in path format is incorrect, and the correct format is: organization/plugin-name');
+        $path = str_replace('\\', '/', trim((string) $path));
+        if (! preg_match('/^[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?\/[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?$/', $path) || str_contains($path, '..')) {
+            $this->output->error('Invalid plugin path. Use: organization/plugin-name (letters or digits, dash/underscore allowed, no dot).');
             return AbstractCommand::FAILURE;
         }
 

--- a/src/AppStore/src/Command/CreateCommand.php
+++ b/src/AppStore/src/Command/CreateCommand.php
@@ -84,7 +84,7 @@ class CreateCommand extends AbstractCommand
             ],
         ];
         if ($pluginType === PluginTypeEnum::Backend || $pluginType === PluginTypeEnum::Mix) {
-            $namespace = $this->createNamespace($path) ?? 'Plugin\\' . ucwords(str_replace('/', '\\', Str::studly($name)));
+            $namespace = $this->createNamespace($path);
 
             $this->createInstallScript($namespace, $path);
             $this->createUninstallScript($namespace, $path);

--- a/src/AppStore/src/Command/CreateCommand.php
+++ b/src/AppStore/src/Command/CreateCommand.php
@@ -30,13 +30,8 @@ class CreateCommand extends AbstractCommand
     public function __invoke(): int
     {
         $path = $this->input->getArgument('path');
-        $name = $this->input->getOption('name');
         $type = $this->input->getOption('type') ?? 'mix';
         $type = PluginTypeEnum::fromValue($type);
-        if (empty($name)) {
-            $this->output->error('Plugin name is empty');
-            return AbstractCommand::FAILURE;
-        }
         if ($type === null) {
             $this->output->error('Plugin type is empty');
             return AbstractCommand::FAILURE;
@@ -47,6 +42,12 @@ class CreateCommand extends AbstractCommand
             $this->output->error(\sprintf('Plugin directory %s already exists', $path));
             return AbstractCommand::FAILURE;
         }
+
+        if (mb_substr_count($path, '/') !== 1) {
+            $this->output->error('The plug-in path format is incorrect, and the correct format is: organization/plugin-name');
+            return AbstractCommand::FAILURE;
+        }
+
         $createDirectors = [
             $pluginPath, $pluginPath . '/src', $pluginPath . '/Database', $pluginPath . '/Database/Migrations', $pluginPath . '/Database/Seeders', $pluginPath . '/web',
         ];
@@ -56,23 +57,23 @@ class CreateCommand extends AbstractCommand
             }
         }
 
-        $this->createMineJson($pluginPath, $name, $type);
+        $this->createMineJson($pluginPath, $type);
         return AbstractCommand::SUCCESS;
     }
 
-    public function createNamespace(string $path, string $name): string
+    public function createNamespace(string $path): string
     {
         $pluginPath = Str::replace(Plugin::PLUGIN_PATH . '/', '', $path);
-        [$orgName] = explode('/', $pluginPath);
-        return 'Plugin\\' . Str::studly($orgName) . '\\' . Str::studly($name);
+        [$orgName, $extName] = explode('/', $pluginPath);
+        return 'Plugin\\' . Str::studly($orgName) . '\\' . Str::studly($extName);
     }
 
-    public function createMineJson(string $path, string $name, PluginTypeEnum $pluginType): void
+    public function createMineJson(string $path, PluginTypeEnum $pluginType): void
     {
         $pluginPath = Str::replace(Plugin::PLUGIN_PATH . '/', '', $path);
 
         $output = new \stdClass();
-        $output->name = $pluginPath ?? $name;
+        $output->name = $pluginPath;
         $output->version = '1.0.0';
         $output->type = $pluginType->value;
         $output->description = $this->input->getOption('description') ?: 'This is a sample plugin';
@@ -83,7 +84,7 @@ class CreateCommand extends AbstractCommand
             ],
         ];
         if ($pluginType === PluginTypeEnum::Backend || $pluginType === PluginTypeEnum::Mix) {
-            $namespace = $this->createNamespace($path, $name) ?? 'Plugin\\' . ucwords(str_replace('/', '\\', Str::studly($name)));
+            $namespace = $this->createNamespace($path) ?? 'Plugin\\' . ucwords(str_replace('/', '\\', Str::studly($name)));
 
             $this->createInstallScript($namespace, $path);
             $this->createUninstallScript($namespace, $path);

--- a/src/AppStore/src/Command/Stub/UninstallScript.stub
+++ b/src/AppStore/src/Command/Stub/UninstallScript.stub
@@ -2,7 +2,7 @@
 
 namespace %namespace%;
 
-class InstallScript {
+class UninstallScript {
 
     public function __invoke(){
         echo "Commands to be executed when uninstalling the plug-in";


### PR DESCRIPTION
Related https://github.com/mineadmin/MineAdmin/issues/697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 创建插件时自动从路径生成命名空间与名称（无需单独输入名称）。
  - 为后端/混合插件自动生成安装/卸载脚本、ConfigProvider 与视图脚本；必要时创建 web 目录。
  - mine.json 中新增 config 条目并改善自动加载映射。

- 改进
  - 路径格式严格校验（必须为 organization/plugin-name），不符合将报错并中止。
  - mine.json 采用更友好的 JSON 编码（保留斜杠与 Unicode，带缩进）。

- 修复
  - 卸载脚本的类名更正，避免与安装脚本混淆。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->