### PR TITLE
fix: 限制 nette/utils 版本为稳定的 4.0 系列，避免安装 dev 或 RC 版本

### DIFF
--- a/src/AppStore/composer.json
+++ b/src/AppStore/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "ext-zip": "*",
         "hyperf/translation": "~3.1.0",
-        "nette/utils": "dev-master",
+        "nette/utils": "4.0.*",
         "hyperf/guzzle": "~3.1"
     },
     "autoload": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **运维更新**
  * 更新内部依赖库版本，优化系统稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->