### PR TITLE
⚡ perf(appstore): 强制使用 CoroutineHandler 修复 HTTP 客户端性能

### DIFF
--- a/src/AppStore/src/Service/Impl/AppStoreServiceImpl.php
+++ b/src/AppStore/src/Service/Impl/AppStoreServiceImpl.php
@@ -14,10 +14,12 @@ namespace Mine\AppStore\Service\Impl;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\HandlerStack;
 use Hyperf\Collection\Arr;
 use Hyperf\Collection\Collection;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Guzzle\ClientFactory;
+use Hyperf\Guzzle\CoroutineHandler;
 use Mine\AppStore\Plugin;
 use Mine\AppStore\Service\AppStoreService;
 
@@ -34,9 +36,11 @@ final class AppStoreServiceImpl implements AppStoreService
         ClientFactory $clientFactory,
         ConfigInterface $config
     ) {
+        $stack = HandlerStack::create(new CoroutineHandler());
         $this->client = $clientFactory->create([
             'base_uri' => 'https://www.mineadmin.com/server/server/',
             'timeout' => 10.0,
+            'handler' => $stack,
         ]);
         $this->config = $config->get('mine-extension');
     }


### PR DESCRIPTION
问题根源：bin/hyperf.php中定义了SWOOLE_HOOK_ALL（包含SWOOLE_HOOK_NATIVE_CURL），Hyperf的ClientFactory检测到该flag后，认为cURL已被Swoole Hook接管， 因此不会自动切换为CoroutineHandler，而是退化使用hooked cURL。

修复方案：手动创建HandlerStack并指定CoroutineHandler，绕过ClientFactory的自动检测逻辑，直接使用Swoole原生非阻塞HTTP客户端

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **性能优化**
  * 改进了应用商店服务的网络请求处理配置，以提升系统稳定性和响应性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->